### PR TITLE
Define dependencies in the platform-io build

### DIFF
--- a/Arduino/justaphone-pio/platformio.ini
+++ b/Arduino/justaphone-pio/platformio.ini
@@ -13,3 +13,8 @@ platform = espressif8266
 board = nodemcuv2
 framework = arduino
 monitor_speed = 9600
+lib_deps = 
+	chris--a/Keypad@^3.1.1
+	adafruit/Adafruit GFX Library@^1.10.1
+	adafruit/Adafruit SSD1306@^2.4.0
+	adafruit/Adafruit BusIO@^1.5.0


### PR DESCRIPTION
@iceman198 - I went through the steps to get this setup locally. When I ran build it a few of the includes couldn't be found. Poking around I found that Platform.io has a way to define dependencies so I used that to include the failing libs. After doing this the build command started working. Here are the changes needed in the platformio.ini file.